### PR TITLE
Safari silently ignores drawImage when the region overflows the canvas

### DIFF
--- a/JGO/canvas.js
+++ b/JGO/canvas.js
@@ -285,8 +285,8 @@ Canvas.prototype.restore = function(x, y, w, h) {
   y = Math.floor(y);
   x = Math.max(x, 0);
   y = Math.max(y, 0);
-  w = Math.min(w, this.backup.width);
-  h = Math.min(h, this.backup.height);
+  w = Math.min(w, this.backup.width - x);
+  h = Math.min(h, this.backup.height - y);
   try {
     this.ctx.drawImage(this.backup, x, y, w, h, x, y, w, h);
   }

--- a/dist/jgoboard-latest.js
+++ b/dist/jgoboard-latest.js
@@ -325,7 +325,7 @@ Board.prototype.getMark = function(c) {
  * Get neighboring coordinates on board.
  *
  * @param {Coordinate} c The coordinate
- * @returns {Array} The array of adjacent coordinates of given type (may be an empty array)
+ * @returns {Array} The array of adjacent coordinates (2-4)
  */
 Board.prototype.getAdjacent = function(c) {
   var coordinates = [], i = c.i, j = c.j;
@@ -353,7 +353,7 @@ Board.prototype.filter = function(c, t) {
   var ret = [];
   for(var i=0, len=c.length; i<len; ++i)
     if(this.stones[c[i].i][c[i].j] == t)
-      ret.push(c);
+      ret.push(c[i]);
   return ret;
 };
 
@@ -430,6 +430,17 @@ Board.prototype.setRaw = function(raw) {
 };
 
 /**
+ * Clone a board. This will only copy stones and marks, not listeners!
+ *
+ * @returns {Object} Cloned board.
+ */
+Board.prototype.clone = function() {
+  var board = new Board();
+  board.setRaw(this.getRaw());
+  return board;
+};
+
+/**
  * Calculate impact of a move on board. Returns a data structure outlining
  * validness of move (success & errorMsg) and possible captures and ko
  * coordinate.
@@ -464,7 +475,7 @@ Board.prototype.playMove = function(coord, stone, ko) {
     if(this.getType(c) == oppType) { // potential capture
       var g = this.getGroup(c);
 
-      if(this.filter(g.neighbors, C.CLEAR).length == 1) {
+      if(this.filter(g.neighbors, C.CLEAR).length === 1) {
         captures = captures.concat(g.group);
         // save captured coordinates so we don't capture them twice
         for(var j=0; j<g.group.length; j++)
@@ -779,8 +790,8 @@ Canvas.prototype.restore = function(x, y, w, h) {
   y = Math.floor(y);
   x = Math.max(x, 0);
   y = Math.max(y, 0);
-  w = Math.min(w, this.backup.width);
-  h = Math.min(h, this.backup.height);
+  w = Math.min(w, this.backup.width - x);
+  h = Math.min(h, this.backup.height - y);
   try {
     this.ctx.drawImage(this.backup, x, y, w, h, x, y, w, h);
   }


### PR DESCRIPTION
Hi.

When I  your demoPlay.html without coordinates on Mac/iOS Safari, DIM_BLACK/DIM_WHITE was not cleared at right and bottom edges.
I found the cause that Safari's drawImage silently ignores when the drawing region overflows the canvas.

This pull request fixes it.